### PR TITLE
Move to stream-first source/formatter pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 ![platforms](https://img.shields.io/badge/platforms-win%20%7C%20linux%20%7C%20macos-7C3AED)
 [![License Info](http://img.shields.io/badge/license-Apache%20License%20v2.0-orange.svg)](https://raw.githubusercontent.com/mbe24/99problems/main/LICENSE)
 
-`99problems` fetches issue and pull request conversations (including comments) from GitHub, GitLab, and Jira, and outputs JSON or YAML.
+`99problems` fetches issue and pull request conversations (including comments) from GitHub, GitLab, and Jira.
+It supports machine-readable output (`json`, `yaml`, `jsonl`/`ndjson`) and a human-readable `text` format.
 
 ## Installation
 
@@ -31,6 +32,9 @@ cargo install problems99
 
 # Fetch Jira issue by key
 99problems get --platform jira --id CLOUD-12817
+
+# Stream as JSON Lines for pipelines
+99problems get -q "repo:github/gitignore is:issue state:open" --output-mode stream --format jsonl
 ```
 
 ## Commands
@@ -101,6 +105,20 @@ Generate all pages to disk:
 
 Committed man pages live in `docs/man/`.
 The `Man Drift` workflow verifies generated output stays in sync with committed files.
+
+## Output Modes
+
+`get` supports two orthogonal controls:
+
+- `--format`: `json`, `yaml`, `jsonl`, `ndjson` (alias of `jsonl`), `text`
+- `--output-mode`: `auto`, `batch`, `stream` (or `--stream`)
+
+Defaults:
+
+- TTY stdout: `--format text`, `--output-mode auto` (resolved to streaming)
+- piped stdout / file output: `--format jsonl`, `--output-mode auto` (resolved to streaming)
+
+Use `--output-mode batch` when you want all-or-nothing output at the end.
 
 ## Shell Completions
 

--- a/docs/man/99problems-get.1
+++ b/docs/man/99problems-get.1
@@ -4,7 +4,7 @@
 .SH NAME
 99problems\-get \- Fetch issue and pull request conversations
 .SH SYNOPSIS
-\fB99problems get\fR [\fB\-q\fR|\fB\-\-query\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-Q\fR|\fB\-\-quiet\fR] [\fB\-r\fR|\fB\-\-repo\fR] [\fB\-\-error\-format\fR] [\fB\-s\fR|\fB\-\-state\fR] [\fB\-l\fR|\fB\-\-labels\fR] [\fB\-a\fR|\fB\-\-author\fR] [\fB\-S\fR|\fB\-\-since\fR] [\fB\-m\fR|\fB\-\-milestone\fR] [\fB\-i\fR|\fB\-\-id\fR] [\fB\-p\fR|\fB\-\-platform\fR] [\fB\-I\fR|\fB\-\-instance\fR] [\fB\-u\fR|\fB\-\-url\fR] [\fB\-t\fR|\fB\-\-type\fR] [\fB\-f\fR|\fB\-\-format\fR] [\fB\-R\fR|\fB\-\-include\-review\-comments\fR] [\fB\-\-no\-comments\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-k\fR|\fB\-\-token\fR] [\fB\-\-jira\-email\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fB99problems get\fR [\fB\-q\fR|\fB\-\-query\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-Q\fR|\fB\-\-quiet\fR] [\fB\-r\fR|\fB\-\-repo\fR] [\fB\-\-error\-format\fR] [\fB\-s\fR|\fB\-\-state\fR] [\fB\-l\fR|\fB\-\-labels\fR] [\fB\-a\fR|\fB\-\-author\fR] [\fB\-S\fR|\fB\-\-since\fR] [\fB\-m\fR|\fB\-\-milestone\fR] [\fB\-i\fR|\fB\-\-id\fR] [\fB\-p\fR|\fB\-\-platform\fR] [\fB\-I\fR|\fB\-\-instance\fR] [\fB\-u\fR|\fB\-\-url\fR] [\fB\-t\fR|\fB\-\-type\fR] [\fB\-f\fR|\fB\-\-format\fR] [\fB\-\-output\-mode\fR] [\fB\-\-stream\fR] [\fB\-R\fR|\fB\-\-include\-review\-comments\fR] [\fB\-\-no\-comments\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-k\fR|\fB\-\-token\fR] [\fB\-\-jira\-email\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Fetch issue and pull request conversations
 .SH OPTIONS
@@ -66,12 +66,22 @@ Content type to fetch [default: issue]
 .br
 [\fIpossible values: \fRissue, pr]
 .TP
-\fB\-f\fR, \fB\-\-format\fR \fI<FORMAT>\fR [default: json]
-Output format
+\fB\-f\fR, \fB\-\-format\fR \fI<FORMAT>\fR
+Output format (default: text for TTY, jsonl for piped/file output)
 .br
 
 .br
-[\fIpossible values: \fRjson, yaml]
+[\fIpossible values: \fRjson, yaml, jsonl, ndjson, text]
+.TP
+\fB\-\-output\-mode\fR \fI<OUTPUT_MODE>\fR
+Output behavior mode
+.br
+
+.br
+[\fIpossible values: \fRauto, batch, stream]
+.TP
+\fB\-\-stream\fR
+Shorthand for \-\-output\-mode stream
 .TP
 \fB\-R\fR, \fB\-\-include\-review\-comments\fR
 Include pull request review comments (inline code comments)
@@ -94,4 +104,4 @@ Print help
 Examples:
   99problems get \-\-repo schemaorg/schemaorg \-\-id 1842
   99problems get \-\-repo github/gitignore \-\-id 2402 \-\-type pr \-\-include\-review\-comments
-  99problems get \-q "repo:owner/repo state:open label:bug" \-\-format yaml
+  99problems get \-q "repo:owner/repo state:open label:bug" \-\-output\-mode stream \-\-format jsonl

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use clap::{Args, ValueEnum};
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use tracing::{debug, info, warn};
 
 use crate::config::{Config, ResolveOptions, token_env_var};
 use crate::error::AppError;
-use crate::format::{Formatter, json::JsonFormatter, yaml::YamlFormatter};
-use crate::model::Conversation;
+use crate::format::{
+    StreamFormatter, json::JsonStreamFormatter, jsonl::JsonLinesFormatter, text::TextFormatter,
+    yaml::YamlStreamFormatter,
+};
 use crate::source::{
     ContentKind, FetchRequest, FetchTarget, Query, Source, github::GitHubSource,
     gitlab::GitLabSource, jira::JiraSource,
@@ -16,6 +18,16 @@ use crate::source::{
 pub(crate) enum OutputFormat {
     Json,
     Yaml,
+    Jsonl,
+    Ndjson,
+    Text,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub(crate) enum OutputMode {
+    Auto,
+    Batch,
+    Stream,
 }
 
 #[derive(Debug, Clone, ValueEnum, PartialEq)]
@@ -52,10 +64,30 @@ impl ContentType {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum ResolvedOutputMode {
+    Batch,
+    Stream,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ResolvedOutputFormat {
+    Json,
+    Yaml,
+    Jsonl,
+    Text,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OutputPlan {
+    mode: ResolvedOutputMode,
+    format: ResolvedOutputFormat,
+}
+
 #[derive(Args, Debug)]
 #[command(
     next_line_help = true,
-    after_help = "Examples:\n  99problems get --repo schemaorg/schemaorg --id 1842\n  99problems get --repo github/gitignore --id 2402 --type pr --include-review-comments\n  99problems get -q \"repo:owner/repo state:open label:bug\" --format yaml"
+    after_help = "Examples:\n  99problems get --repo schemaorg/schemaorg --id 1842\n  99problems get --repo github/gitignore --id 2402 --type pr --include-review-comments\n  99problems get -q \"repo:owner/repo state:open label:bug\" --output-mode stream --format jsonl"
 )]
 pub(crate) struct GetArgs {
     /// Full search query (same syntax as the platform's web UI search bar)
@@ -107,9 +139,17 @@ pub(crate) struct GetArgs {
     #[arg(short = 't', long = "type", value_enum)]
     pub(crate) kind: Option<ContentType>,
 
-    /// Output format
-    #[arg(short = 'f', long, value_enum, default_value = "json")]
-    pub(crate) format: OutputFormat,
+    /// Output format (default: text for TTY, jsonl for piped/file output)
+    #[arg(short = 'f', long, value_enum)]
+    pub(crate) format: Option<OutputFormat>,
+
+    /// Output behavior mode
+    #[arg(long, value_enum)]
+    pub(crate) output_mode: Option<OutputMode>,
+
+    /// Shorthand for --output-mode stream
+    #[arg(long, conflicts_with = "output_mode")]
+    pub(crate) stream: bool,
 
     /// Include pull request review comments (inline code comments)
     #[arg(short = 'R', long)]
@@ -140,23 +180,35 @@ pub(crate) struct GetArgs {
 /// or output writing fails.
 pub(crate) fn run(args: &GetArgs) -> Result<()> {
     let cfg = load_config_for_get(args)?;
+    emit_get_warnings(&cfg, args)?;
+
+    let source = build_source_for_platform(&cfg)?;
+    let req = build_fetch_request(&cfg, args)?;
+    let output_plan = resolve_output_plan(args);
     debug!(
         platform = %cfg.platform,
         kind = %cfg.kind,
         include_comments = !args.no_comments,
         include_review_comments = args.include_review_comments,
+        output_mode = ?output_plan.mode,
+        output_format = ?output_plan.format,
         "resolved get configuration"
     );
-    emit_get_warnings(&cfg, args)?;
 
-    let source = build_source_for_platform(&cfg)?;
-    let conversations = fetch_get_conversations(source.as_ref(), &cfg, args)?;
-    info!(
-        platform = %cfg.platform,
-        count = conversations.len(),
-        "fetched conversations"
-    );
-    write_formatted_output(args.format, args.output.as_deref(), &conversations)
+    match output_plan.mode {
+        ResolvedOutputMode::Batch => write_batch_output(
+            source.as_ref(),
+            &req,
+            output_plan.format,
+            args.output.as_deref(),
+        ),
+        ResolvedOutputMode::Stream => write_stream_output(
+            source.as_ref(),
+            &req,
+            output_plan.format,
+            args.output.as_deref(),
+        ),
+    }
 }
 
 fn load_config_for_get(args: &GetArgs) -> Result<Config> {
@@ -222,62 +274,76 @@ fn build_source_for_platform(cfg: &Config) -> Result<Box<dyn Source>> {
     }
 }
 
-fn fetch_get_conversations(
-    source: &dyn Source,
-    cfg: &Config,
-    args: &GetArgs,
-) -> Result<Vec<Conversation>> {
+fn build_fetch_request(cfg: &Config, args: &GetArgs) -> Result<FetchRequest> {
     let repo = cfg.repo.clone();
     let state = cfg.state.clone();
 
     if let Some(id) = &args.id {
-        return fetch_get_by_id(source, cfg, args, repo, id);
+        let ignored_flags = ignored_flags_in_id_mode(args);
+        if !ignored_flags.is_empty() {
+            warn!(
+                "Warning: when using --id/--issue, these flags are ignored: {}",
+                ignored_flags.join(", ")
+            );
+        }
+
+        let id_kind = if cfg.kind == "pr" {
+            ContentKind::Pr
+        } else {
+            ContentKind::Issue
+        };
+        let kind_explicit = args.kind.is_some() || cfg.kind == "pr";
+
+        let repo_for_id = if cfg.platform == "jira" {
+            repo.unwrap_or_default()
+        } else {
+            repo.ok_or_else(|| AppError::usage("--repo is required when using --id/--issue"))?
+        };
+
+        return Ok(FetchRequest {
+            target: FetchTarget::Id {
+                repo: repo_for_id,
+                id: id.clone(),
+                kind: id_kind,
+                allow_fallback_to_pr: !kind_explicit && matches!(id_kind, ContentKind::Issue),
+            },
+            per_page: cfg.per_page,
+            token: cfg.token.clone(),
+            jira_email: cfg.jira_email.clone(),
+            include_comments: !args.no_comments,
+            include_review_comments: args.include_review_comments,
+        });
     }
 
-    fetch_get_by_search(source, cfg, args, repo, state)
-}
-
-fn fetch_get_by_id(
-    source: &dyn Source,
-    cfg: &Config,
-    args: &GetArgs,
-    repo: Option<String>,
-    id: &str,
-) -> Result<Vec<Conversation>> {
-    let ignored_flags = ignored_flags_in_id_mode(args);
-    if !ignored_flags.is_empty() {
-        warn!(
-            "Warning: when using --id/--issue, these flags are ignored: {}",
-            ignored_flags.join(", ")
-        );
+    let query = Query::build(
+        args.query.clone(),
+        &cfg.kind,
+        repo,
+        state,
+        args.labels.clone(),
+        args.author.clone(),
+        args.since.clone(),
+        args.milestone.clone(),
+        cfg.per_page,
+        cfg.token.clone(),
+    );
+    if query.raw.trim().is_empty() {
+        return Err(AppError::usage(
+            "No query specified. Use -q or provide --repo/--state/--labels.",
+        )
+        .into());
     }
 
-    let id_kind = if cfg.kind == "pr" {
-        ContentKind::Pr
-    } else {
-        ContentKind::Issue
-    };
-    let kind_explicit = args.kind.is_some() || cfg.kind == "pr";
-
-    let repo_for_id = if cfg.platform == "jira" {
-        repo.unwrap_or_default()
-    } else {
-        repo.ok_or_else(|| AppError::usage("--repo is required when using --id/--issue"))?
-    };
-    let req = FetchRequest {
-        target: FetchTarget::Id {
-            repo: repo_for_id,
-            id: id.to_string(),
-            kind: id_kind,
-            allow_fallback_to_pr: !kind_explicit && matches!(id_kind, ContentKind::Issue),
+    Ok(FetchRequest {
+        target: FetchTarget::Search {
+            raw_query: query.raw,
         },
-        per_page: cfg.per_page,
-        token: cfg.token.clone(),
+        per_page: query.per_page,
+        token: query.token,
         jira_email: cfg.jira_email.clone(),
         include_comments: !args.no_comments,
         include_review_comments: args.include_review_comments,
-    };
-    source.fetch(&req)
+    })
 }
 
 fn ignored_flags_in_id_mode(args: &GetArgs) -> Vec<&'static str> {
@@ -303,71 +369,184 @@ fn ignored_flags_in_id_mode(args: &GetArgs) -> Vec<&'static str> {
     ignored_flags
 }
 
-fn fetch_get_by_search(
-    source: &dyn Source,
-    cfg: &Config,
-    args: &GetArgs,
-    repo: Option<String>,
-    state: Option<String>,
-) -> Result<Vec<Conversation>> {
-    let query = Query::build(
-        args.query.clone(),
-        &cfg.kind,
-        repo,
-        state,
-        args.labels.clone(),
-        args.author.clone(),
-        args.since.clone(),
-        args.milestone.clone(),
-        cfg.per_page,
-        cfg.token.clone(),
-    );
-    if query.raw.trim().is_empty() {
-        return Err(AppError::usage(
-            "No query specified. Use -q or provide --repo/--state/--labels.",
-        )
-        .into());
-    }
-    let req = FetchRequest {
-        target: FetchTarget::Search {
-            raw_query: query.raw,
-        },
-        per_page: query.per_page,
-        token: query.token,
-        jira_email: cfg.jira_email.clone(),
-        include_comments: !args.no_comments,
-        include_review_comments: args.include_review_comments,
+fn resolve_output_plan(args: &GetArgs) -> OutputPlan {
+    let stdout_is_tty = args.output.is_none() && std::io::stdout().is_terminal();
+    resolve_output_plan_with_tty(args, stdout_is_tty)
+}
+
+fn resolve_output_plan_with_tty(args: &GetArgs, stdout_is_tty: bool) -> OutputPlan {
+    let mode = if args.stream {
+        OutputMode::Stream
+    } else {
+        args.output_mode.unwrap_or(OutputMode::Auto)
     };
-    source.fetch(&req)
-}
+    let resolved_mode = match mode {
+        OutputMode::Batch => ResolvedOutputMode::Batch,
+        OutputMode::Auto | OutputMode::Stream => ResolvedOutputMode::Stream,
+    };
 
-fn build_formatter(format: OutputFormat) -> Box<dyn Formatter> {
-    match format {
-        OutputFormat::Json => Box::new(JsonFormatter),
-        OutputFormat::Yaml => Box::new(YamlFormatter),
+    let selected_format = args.format.unwrap_or({
+        if stdout_is_tty {
+            OutputFormat::Text
+        } else {
+            OutputFormat::Jsonl
+        }
+    });
+    let resolved_format = match selected_format {
+        OutputFormat::Json => ResolvedOutputFormat::Json,
+        OutputFormat::Yaml => ResolvedOutputFormat::Yaml,
+        OutputFormat::Jsonl | OutputFormat::Ndjson => ResolvedOutputFormat::Jsonl,
+        OutputFormat::Text => ResolvedOutputFormat::Text,
+    };
+
+    OutputPlan {
+        mode: resolved_mode,
+        format: resolved_format,
     }
 }
 
-fn write_formatted_output(
-    format: OutputFormat,
-    output_path: Option<&str>,
-    conversations: &[Conversation],
-) -> Result<()> {
-    let formatter = build_formatter(format);
-    let output = formatter.format(conversations)?;
+fn build_formatter(format: ResolvedOutputFormat) -> Box<dyn StreamFormatter> {
+    match format {
+        ResolvedOutputFormat::Json => Box::new(JsonStreamFormatter::new()),
+        ResolvedOutputFormat::Yaml => Box::new(YamlStreamFormatter::new()),
+        ResolvedOutputFormat::Jsonl => Box::new(JsonLinesFormatter),
+        ResolvedOutputFormat::Text => Box::new(TextFormatter::new()),
+    }
+}
 
-    match output_path {
-        Some(path) => {
-            let mut file = std::fs::File::create(path)?;
-            file.write_all(output.as_bytes())?;
-            info!(count = conversations.len(), path = %path, "wrote conversations to file");
-        }
-        None => println!("{output}"),
+fn write_batch_output(
+    source: &dyn Source,
+    req: &FetchRequest,
+    format: ResolvedOutputFormat,
+    output_path: Option<&str>,
+) -> Result<()> {
+    let conversations = source.fetch(req)?;
+    let mut formatter = build_formatter(format);
+    let mut rendered = Vec::new();
+    formatter.begin(&mut rendered)?;
+    for conversation in &conversations {
+        formatter.write_item(&mut rendered, conversation)?;
+    }
+    formatter.finish(&mut rendered)?;
+
+    if let Some(path) = output_path {
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(&rendered)?;
+        info!(count = conversations.len(), path = %path, "wrote conversations to file");
+    } else {
+        let mut out = std::io::stdout();
+        out.write_all(&rendered)?;
+        out.flush()?;
+        info!(count = conversations.len(), "wrote conversations to stdout");
     }
 
     Ok(())
 }
 
+fn write_stream_output(
+    source: &dyn Source,
+    req: &FetchRequest,
+    format: ResolvedOutputFormat,
+    output_path: Option<&str>,
+) -> Result<()> {
+    let mut formatter = build_formatter(format);
+    let mut writer: Box<dyn Write> = match output_path {
+        Some(path) => Box::new(std::fs::File::create(path)?),
+        None => Box::new(std::io::stdout()),
+    };
+    formatter.begin(&mut writer)?;
+
+    let mut emitted = 0usize;
+    let fetch_result = source.fetch_stream(req, &mut |conversation| {
+        formatter.write_item(&mut writer, &conversation)?;
+        emitted += 1;
+        Ok(())
+    });
+    if let Err(err) = fetch_result {
+        return Err(AppError::provider(format!(
+            "Fetch failed after writing {emitted} conversations: {err}"
+        ))
+        .into());
+    }
+
+    formatter.finish(&mut writer)?;
+    writer.flush()?;
+    if let Some(path) = output_path {
+        info!(count = emitted, path = %path, "stream-wrote conversations to file");
+    } else {
+        info!(count = emitted, "stream-wrote conversations to stdout");
+    }
+    Ok(())
+}
+
 fn looks_like_atlassian_api_token(token: &str) -> bool {
     token.starts_with("AT") && !token.contains(':') && !token.contains('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args() -> GetArgs {
+        GetArgs {
+            query: None,
+            repo: Some("owner/repo".into()),
+            state: None,
+            labels: None,
+            author: None,
+            since: None,
+            milestone: None,
+            id: Some("1".into()),
+            platform: None,
+            instance: None,
+            url: None,
+            kind: None,
+            format: None,
+            output_mode: None,
+            stream: false,
+            include_review_comments: false,
+            no_comments: false,
+            output: None,
+            token: None,
+            jira_email: None,
+        }
+    }
+
+    #[test]
+    fn resolve_output_plan_defaults_to_text_for_tty() {
+        let plan = resolve_output_plan_with_tty(&args(), true);
+        assert!(matches!(plan.mode, ResolvedOutputMode::Stream));
+        assert!(matches!(plan.format, ResolvedOutputFormat::Text));
+    }
+
+    #[test]
+    fn resolve_output_plan_defaults_to_jsonl_for_non_tty() {
+        let plan = resolve_output_plan_with_tty(&args(), false);
+        assert!(matches!(plan.mode, ResolvedOutputMode::Stream));
+        assert!(matches!(plan.format, ResolvedOutputFormat::Jsonl));
+    }
+
+    #[test]
+    fn resolve_output_plan_honors_batch_mode() {
+        let mut args = args();
+        args.output_mode = Some(OutputMode::Batch);
+        let plan = resolve_output_plan_with_tty(&args, false);
+        assert!(matches!(plan.mode, ResolvedOutputMode::Batch));
+    }
+
+    #[test]
+    fn resolve_output_plan_stream_shorthand_wins() {
+        let mut args = args();
+        args.stream = true;
+        let plan = resolve_output_plan_with_tty(&args, false);
+        assert!(matches!(plan.mode, ResolvedOutputMode::Stream));
+    }
+
+    #[test]
+    fn resolve_output_plan_maps_ndjson_to_jsonl() {
+        let mut args = args();
+        args.format = Some(OutputFormat::Ndjson);
+        let plan = resolve_output_plan_with_tty(&args, false);
+        assert!(matches!(plan.format, ResolvedOutputFormat::Jsonl));
+    }
 }

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -1,12 +1,43 @@
-use super::Formatter;
+use super::StreamFormatter;
 use crate::model::Conversation;
 use anyhow::Result;
+use std::io::Write;
 
-pub struct JsonFormatter;
+#[derive(Default)]
+pub struct JsonStreamFormatter {
+    wrote_item: bool,
+}
 
-impl Formatter for JsonFormatter {
-    fn format(&self, conversations: &[Conversation]) -> Result<String> {
-        Ok(serde_json::to_string_pretty(conversations)?)
+impl JsonStreamFormatter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { wrote_item: false }
+    }
+}
+
+impl StreamFormatter for JsonStreamFormatter {
+    fn begin(&mut self, out: &mut dyn Write) -> Result<()> {
+        out.write_all(b"[\n")?;
+        Ok(())
+    }
+
+    fn write_item(&mut self, out: &mut dyn Write, conversation: &Conversation) -> Result<()> {
+        if self.wrote_item {
+            out.write_all(b",\n")?;
+        }
+        let rendered = serde_json::to_string_pretty(conversation)?;
+        out.write_all(rendered.as_bytes())?;
+        self.wrote_item = true;
+        Ok(())
+    }
+
+    fn finish(&mut self, out: &mut dyn Write) -> Result<()> {
+        if self.wrote_item {
+            out.write_all(b"\n]\n")?;
+        } else {
+            out.write_all(b"]\n")?;
+        }
+        Ok(())
     }
 }
 
@@ -15,8 +46,8 @@ mod tests {
     use super::*;
     use crate::model::Comment;
 
-    fn sample() -> Vec<Conversation> {
-        vec![Conversation {
+    fn sample() -> Conversation {
+        Conversation {
             id: "42".into(),
             title: "Test issue".into(),
             state: "closed".into(),
@@ -30,21 +61,27 @@ mod tests {
                 review_line: None,
                 review_side: None,
             }],
-        }]
+        }
     }
 
     #[test]
-    fn formats_valid_json() {
-        let out = JsonFormatter.format(&sample()).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+    fn formats_valid_json_array() {
+        let mut formatter = JsonStreamFormatter::new();
+        let mut out = Vec::new();
+        formatter.begin(&mut out).unwrap();
+        formatter.write_item(&mut out, &sample()).unwrap();
+        formatter.finish(&mut out).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(parsed[0]["id"], "42");
-        assert_eq!(parsed[0]["title"], "Test issue");
-        assert_eq!(parsed[0]["comments"][0]["author"], "user1");
     }
 
     #[test]
-    fn empty_slice_produces_empty_array() {
-        let out = JsonFormatter.format(&[]).unwrap();
-        assert_eq!(out.trim(), "[]");
+    fn empty_output_is_empty_array() {
+        let mut formatter = JsonStreamFormatter::new();
+        let mut out = Vec::new();
+        formatter.begin(&mut out).unwrap();
+        formatter.finish(&mut out).unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "[\n]\n");
     }
 }

--- a/src/format/jsonl.rs
+++ b/src/format/jsonl.rs
@@ -1,0 +1,52 @@
+use super::StreamFormatter;
+use crate::model::Conversation;
+use anyhow::Result;
+use std::io::Write;
+
+pub struct JsonLinesFormatter;
+
+impl StreamFormatter for JsonLinesFormatter {
+    fn begin(&mut self, _out: &mut dyn Write) -> Result<()> {
+        Ok(())
+    }
+
+    fn write_item(&mut self, out: &mut dyn Write, conversation: &Conversation) -> Result<()> {
+        serde_json::to_writer(&mut *out, conversation)?;
+        out.write_all(b"\n")?;
+        Ok(())
+    }
+
+    fn finish(&mut self, _out: &mut dyn Write) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Conversation;
+
+    #[test]
+    fn emits_one_json_object_per_line() {
+        let mut formatter = JsonLinesFormatter;
+        let mut out = Vec::new();
+        formatter.begin(&mut out).unwrap();
+        formatter
+            .write_item(
+                &mut out,
+                &Conversation {
+                    id: "1".into(),
+                    title: "t".into(),
+                    state: "open".into(),
+                    body: None,
+                    comments: vec![],
+                },
+            )
+            .unwrap();
+        formatter.finish(&mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text.lines().count(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(text.lines().next().unwrap()).unwrap();
+        assert_eq!(parsed["id"], "1");
+    }
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,15 +1,32 @@
 use crate::model::Conversation;
 use anyhow::Result;
+use std::io::Write;
 
 pub mod json;
+pub mod jsonl;
+pub mod text;
 pub mod yaml;
 
-/// A pluggable output formatter for conversations.
-pub trait Formatter {
-    /// Format conversations into a serialized output string.
+/// A pluggable streaming formatter for conversations.
+pub trait StreamFormatter {
+    /// Write optional format prefix.
     ///
     /// # Errors
     ///
-    /// Returns an error if serialization fails.
-    fn format(&self, conversations: &[Conversation]) -> Result<String>;
+    /// Returns an error if writing fails.
+    fn begin(&mut self, out: &mut dyn Write) -> Result<()>;
+
+    /// Write one conversation item.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing fails.
+    fn write_item(&mut self, out: &mut dyn Write, conversation: &Conversation) -> Result<()>;
+
+    /// Write optional format suffix.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing fails.
+    fn finish(&mut self, out: &mut dyn Write) -> Result<()>;
 }

--- a/src/format/text.rs
+++ b/src/format/text.rs
@@ -1,0 +1,73 @@
+use super::StreamFormatter;
+use crate::model::{Comment, Conversation};
+use anyhow::Result;
+use std::io::Write;
+
+#[derive(Default)]
+pub struct TextFormatter {
+    index: usize,
+}
+
+impl TextFormatter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { index: 0 }
+    }
+}
+
+impl StreamFormatter for TextFormatter {
+    fn begin(&mut self, _out: &mut dyn Write) -> Result<()> {
+        Ok(())
+    }
+
+    fn write_item(&mut self, out: &mut dyn Write, conversation: &Conversation) -> Result<()> {
+        self.index += 1;
+        writeln!(out, "Conversation {}", self.index)?;
+        writeln!(out, "id: {}", conversation.id)?;
+        writeln!(out, "title: {}", conversation.title)?;
+        writeln!(out, "state: {}", conversation.state)?;
+        writeln!(
+            out,
+            "body: {}",
+            conversation.body.as_deref().unwrap_or("(none)")
+        )?;
+        writeln!(out, "comments: {}", conversation.comments.len())?;
+        for (idx, comment) in conversation.comments.iter().enumerate() {
+            render_comment(out, idx, comment)?;
+        }
+        writeln!(out, "---")?;
+        Ok(())
+    }
+
+    fn finish(&mut self, _out: &mut dyn Write) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn render_comment(out: &mut dyn Write, index: usize, comment: &Comment) -> Result<()> {
+    writeln!(
+        out,
+        "  [{}] {} {}",
+        index + 1,
+        comment.created_at,
+        comment.author.as_deref().unwrap_or("unknown")
+    )?;
+    if let Some(kind) = comment.kind.as_deref() {
+        writeln!(out, "      kind: {kind}")?;
+    }
+    if let Some(path) = comment.review_path.as_deref() {
+        writeln!(out, "      review_path: {path}")?;
+    }
+    if let Some(line) = comment.review_line {
+        writeln!(out, "      review_line: {line}")?;
+    }
+    if let Some(side) = comment.review_side.as_deref() {
+        writeln!(out, "      review_side: {side}")?;
+    }
+    writeln!(
+        out,
+        "      {}",
+        comment.body.as_deref().unwrap_or("(no body)")
+    )?;
+    Ok(())
+}

--- a/src/format/yaml.rs
+++ b/src/format/yaml.rs
@@ -1,12 +1,49 @@
-use super::Formatter;
+use super::StreamFormatter;
 use crate::model::Conversation;
 use anyhow::Result;
+use std::io::Write;
 
-pub struct YamlFormatter;
+#[derive(Default)]
+pub struct YamlStreamFormatter {
+    wrote_item: bool,
+}
 
-impl Formatter for YamlFormatter {
-    fn format(&self, conversations: &[Conversation]) -> Result<String> {
-        Ok(serde_yaml::to_string(conversations)?)
+impl YamlStreamFormatter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { wrote_item: false }
+    }
+}
+
+impl StreamFormatter for YamlStreamFormatter {
+    fn begin(&mut self, _out: &mut dyn Write) -> Result<()> {
+        Ok(())
+    }
+
+    fn write_item(&mut self, out: &mut dyn Write, conversation: &Conversation) -> Result<()> {
+        let rendered = serde_yaml::to_string(conversation)?;
+        if self.wrote_item {
+            out.write_all(b"\n")?;
+        }
+        for (idx, line) in rendered.lines().enumerate() {
+            if idx == 0 {
+                out.write_all(b"- ")?;
+                out.write_all(line.as_bytes())?;
+            } else {
+                out.write_all(b"\n  ")?;
+                out.write_all(line.as_bytes())?;
+            }
+        }
+        out.write_all(b"\n")?;
+        self.wrote_item = true;
+        Ok(())
+    }
+
+    fn finish(&mut self, out: &mut dyn Write) -> Result<()> {
+        if !self.wrote_item {
+            out.write_all(b"[]\n")?;
+        }
+        Ok(())
     }
 }
 
@@ -15,8 +52,8 @@ mod tests {
     use super::*;
     use crate::model::Comment;
 
-    fn sample() -> Vec<Conversation> {
-        vec![Conversation {
+    fn sample() -> Conversation {
+        Conversation {
             id: "7".into(),
             title: "YAML issue".into(),
             state: "open".into(),
@@ -30,20 +67,27 @@ mod tests {
                 review_line: None,
                 review_side: None,
             }],
-        }]
+        }
     }
 
     #[test]
     fn formats_valid_yaml() {
-        let out = YamlFormatter.format(&sample()).unwrap();
-        let parsed: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        let mut formatter = YamlStreamFormatter::new();
+        let mut out = Vec::new();
+        formatter.begin(&mut out).unwrap();
+        formatter.write_item(&mut out, &sample()).unwrap();
+        formatter.finish(&mut out).unwrap();
+
+        let parsed: serde_yaml::Value = serde_yaml::from_slice(&out).unwrap();
         assert_eq!(parsed[0]["title"], "YAML issue");
-        assert_eq!(parsed[0]["id"], "7");
     }
 
     #[test]
-    fn empty_slice_produces_empty_yaml_list() {
-        let out = YamlFormatter.format(&[]).unwrap();
-        assert_eq!(out.trim(), "[]");
+    fn empty_output_is_empty_yaml_list() {
+        let mut formatter = YamlStreamFormatter::new();
+        let mut out = Vec::new();
+        formatter.begin(&mut out).unwrap();
+        formatter.finish(&mut out).unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "[]\n");
     }
 }

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -143,11 +143,17 @@ impl GitHubSource {
         })
     }
 
-    fn search(&self, req: &FetchRequest, raw_query: &str) -> Result<Vec<Conversation>> {
+    fn search_stream(
+        &self,
+        req: &FetchRequest,
+        raw_query: &str,
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         let search_url = format!("{GITHUB_API_BASE}/search/issues");
         let mut page = 1u32;
-        let mut all_items: Vec<SearchItem> = vec![];
+        let mut emitted = 0usize;
         let per_page = Self::bounded_per_page(req.per_page);
+        let repo_from_query = extract_repo(raw_query);
 
         loop {
             debug!(page, per_page, "fetching GitHub search page");
@@ -175,17 +181,7 @@ impl GitHubSource {
                 page, "decoded GitHub search page"
             );
             let done = search.items.len() < per_page as usize;
-            all_items.extend(search.items);
-            if done {
-                break;
-            }
-            page += 1;
-        }
-
-        let repo_from_query = extract_repo(raw_query);
-        all_items
-            .into_iter()
-            .map(|item| {
+            for item in search.items {
                 let repo = item
                     .repository_url
                     .as_deref()
@@ -198,7 +194,7 @@ impl GitHubSource {
                         ))
                     })?;
 
-                self.fetch_conversation(
+                let conversation = self.fetch_conversation(
                     &repo,
                     ConversationSeed {
                         id: item.number,
@@ -208,19 +204,28 @@ impl GitHubSource {
                         is_pr: item.pull_request.is_some(),
                     },
                     req,
-                )
-            })
-            .collect()
+                )?;
+                emit(conversation)?;
+                emitted += 1;
+            }
+            if done {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(emitted)
     }
 
-    fn fetch_by_id(
+    fn fetch_by_id_stream(
         &self,
         req: &FetchRequest,
         repo: &str,
         id: &str,
         kind: ContentKind,
         allow_fallback_to_pr: bool,
-    ) -> Result<Vec<Conversation>> {
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         let issue_id = id.parse::<u64>().map_err(|_| {
             AppError::usage(format!("GitHub expects a numeric issue/PR id, got '{id}'."))
         })?;
@@ -260,7 +265,7 @@ impl GitHubSource {
             _ => {}
         }
 
-        Ok(vec![self.fetch_conversation(
+        let conversation = self.fetch_conversation(
             repo,
             ConversationSeed {
                 id: issue.number,
@@ -270,20 +275,26 @@ impl GitHubSource {
                 is_pr,
             },
             req,
-        )?])
+        )?;
+        emit(conversation)?;
+        Ok(1)
     }
 }
 
 impl Source for GitHubSource {
-    fn fetch(&self, req: &FetchRequest) -> Result<Vec<Conversation>> {
+    fn fetch_stream(
+        &self,
+        req: &FetchRequest,
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         match &req.target {
-            FetchTarget::Search { raw_query } => self.search(req, raw_query),
+            FetchTarget::Search { raw_query } => self.search_stream(req, raw_query, emit),
             FetchTarget::Id {
                 repo,
                 id,
                 kind,
                 allow_fallback_to_pr,
-            } => self.fetch_by_id(req, repo, id, *kind, *allow_fallback_to_pr),
+            } => self.fetch_by_id_stream(req, repo, id, *kind, *allow_fallback_to_pr, emit),
         }
     }
 }

--- a/src/source/gitlab.rs
+++ b/src/source/gitlab.rs
@@ -63,6 +63,31 @@ impl GitLabSource {
         allow_unauthenticated_empty: bool,
     ) -> Result<Vec<T>> {
         let mut results = vec![];
+        self.get_pages_stream(
+            url,
+            params,
+            token,
+            per_page,
+            allow_unauthenticated_empty,
+            &mut |item| {
+                results.push(item);
+                Ok(())
+            },
+        )?;
+        Ok(results)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn get_pages_stream<T: for<'de> Deserialize<'de>>(
+        &self,
+        url: &str,
+        params: &[(String, String)],
+        token: Option<&str>,
+        per_page: u32,
+        allow_unauthenticated_empty: bool,
+        emit: &mut dyn FnMut(T) -> Result<()>,
+    ) -> Result<usize> {
+        let mut emitted = 0usize;
         let mut page = 1u32;
         let per_page = Self::bounded_per_page(per_page);
 
@@ -81,7 +106,7 @@ impl GitLabSource {
                     && token.is_none()
                     && (status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN)
                 {
-                    return Ok(vec![]);
+                    return Ok(0);
                 }
                 if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
                     let body = resp.text()?;
@@ -115,7 +140,10 @@ impl GitLabSource {
                 .json()
                 .map_err(|err| app_error_from_decode("GitLab", "page fetch", err))?;
             trace!(count = items.len(), page, "decoded GitLab page");
-            results.extend(items);
+            for item in items {
+                emit(item)?;
+                emitted += 1;
+            }
 
             if next_page.is_empty() {
                 break;
@@ -124,7 +152,7 @@ impl GitLabSource {
             page = next_page.parse::<u32>().unwrap_or(page + 1);
         }
 
-        Ok(results)
+        Ok(emitted)
     }
 
     fn get_one<T: for<'de> Deserialize<'de>>(
@@ -248,7 +276,12 @@ impl GitLabSource {
         })
     }
 
-    fn search(&self, req: &FetchRequest, raw_query: &str) -> Result<Vec<Conversation>> {
+    fn search_stream(
+        &self,
+        req: &FetchRequest,
+        raw_query: &str,
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         let filters = parse_gitlab_query(raw_query);
         let repo = filters
             .repo
@@ -261,16 +294,19 @@ impl GitLabSource {
             .to_string();
         let project = encode_project_path(&repo);
         let params = build_search_params(&filters);
+        let mut emitted = 0usize;
 
         match filters.kind {
             ContentKind::Issue => {
                 let url = format!("{}/api/v4/projects/{project}/issues", self.base_url);
-                let issues: Vec<GitLabIssueItem> =
-                    self.get_pages(&url, &params, req.token.as_deref(), req.per_page, false)?;
-                issues
-                    .into_iter()
-                    .map(|i| {
-                        self.fetch_conversation(
+                self.get_pages_stream(
+                    &url,
+                    &params,
+                    req.token.as_deref(),
+                    req.per_page,
+                    false,
+                    &mut |i: GitLabIssueItem| {
+                        let conversation = self.fetch_conversation(
                             &repo,
                             ConversationSeed {
                                 id: i.iid,
@@ -280,17 +316,23 @@ impl GitLabSource {
                                 is_pr: false,
                             },
                             req,
-                        )
-                    })
-                    .collect()
+                        )?;
+                        emit(conversation)?;
+                        emitted += 1;
+                        Ok(())
+                    },
+                )?;
             }
             ContentKind::Pr => {
                 let url = format!("{}/api/v4/projects/{project}/merge_requests", self.base_url);
-                let mrs: Vec<GitLabMergeRequestItem> =
-                    self.get_pages(&url, &params, req.token.as_deref(), req.per_page, false)?;
-                mrs.into_iter()
-                    .map(|mr| {
-                        self.fetch_conversation(
+                self.get_pages_stream(
+                    &url,
+                    &params,
+                    req.token.as_deref(),
+                    req.per_page,
+                    false,
+                    &mut |mr: GitLabMergeRequestItem| {
+                        let conversation = self.fetch_conversation(
                             &repo,
                             ConversationSeed {
                                 id: mr.iid,
@@ -300,11 +342,15 @@ impl GitLabSource {
                                 is_pr: true,
                             },
                             req,
-                        )
-                    })
-                    .collect()
+                        )?;
+                        emit(conversation)?;
+                        emitted += 1;
+                        Ok(())
+                    },
+                )?;
             }
         }
+        Ok(emitted)
     }
 
     fn fetch_issue_by_iid(
@@ -332,21 +378,22 @@ impl GitLabSource {
         self.get_one(&url, token)
     }
 
-    fn fetch_by_id(
+    fn fetch_by_id_stream(
         &self,
         req: &FetchRequest,
         repo: &str,
         id: &str,
         kind: ContentKind,
         allow_fallback_to_pr: bool,
-    ) -> Result<Vec<Conversation>> {
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         let iid = id.parse::<u64>().map_err(|_| {
             AppError::usage(format!("GitLab expects a numeric issue/MR id, got '{id}'."))
         })?;
         match kind {
             ContentKind::Issue => {
                 if let Some(issue) = self.fetch_issue_by_iid(repo, iid, req.token.as_deref())? {
-                    return Ok(vec![self.fetch_conversation(
+                    let conversation = self.fetch_conversation(
                         repo,
                         ConversationSeed {
                             id: issue.iid,
@@ -356,7 +403,9 @@ impl GitLabSource {
                             is_pr: false,
                         },
                         req,
-                    )?]);
+                    )?;
+                    emit(conversation)?;
+                    return Ok(1);
                 }
 
                 if allow_fallback_to_pr
@@ -365,7 +414,7 @@ impl GitLabSource {
                     warn!(
                         "Warning: --id defaulted to issue, but found MR !{iid}; use --type pr for clarity."
                     );
-                    return Ok(vec![self.fetch_conversation(
+                    let conversation = self.fetch_conversation(
                         repo,
                         ConversationSeed {
                             id: mr.iid,
@@ -375,14 +424,16 @@ impl GitLabSource {
                             is_pr: true,
                         },
                         req,
-                    )?]);
+                    )?;
+                    emit(conversation)?;
+                    return Ok(1);
                 }
 
                 Err(AppError::not_found(format!("Issue #{iid} not found in repo {repo}.")).into())
             }
             ContentKind::Pr => {
                 if let Some(mr) = self.fetch_mr_by_iid(repo, iid, req.token.as_deref())? {
-                    return Ok(vec![self.fetch_conversation(
+                    let conversation = self.fetch_conversation(
                         repo,
                         ConversationSeed {
                             id: mr.iid,
@@ -392,7 +443,9 @@ impl GitLabSource {
                             is_pr: true,
                         },
                         req,
-                    )?]);
+                    )?;
+                    emit(conversation)?;
+                    return Ok(1);
                 }
 
                 if self
@@ -415,15 +468,19 @@ impl GitLabSource {
 }
 
 impl Source for GitLabSource {
-    fn fetch(&self, req: &FetchRequest) -> Result<Vec<Conversation>> {
+    fn fetch_stream(
+        &self,
+        req: &FetchRequest,
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         match &req.target {
-            FetchTarget::Search { raw_query } => self.search(req, raw_query),
+            FetchTarget::Search { raw_query } => self.search_stream(req, raw_query, emit),
             FetchTarget::Id {
                 repo,
                 id,
                 kind,
                 allow_fallback_to_pr,
-            } => self.fetch_by_id(req, repo, id, *kind, *allow_fallback_to_pr),
+            } => self.fetch_by_id_stream(req, repo, id, *kind, *allow_fallback_to_pr, emit),
         }
     }
 }

--- a/src/source/jira.rs
+++ b/src/source/jira.rs
@@ -172,7 +172,12 @@ impl JiraSource {
         Ok(out)
     }
 
-    fn search(&self, req: &FetchRequest, raw_query: &str) -> Result<Vec<Conversation>> {
+    fn search_stream(
+        &self,
+        req: &FetchRequest,
+        raw_query: &str,
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         let filters = parse_jira_query(raw_query);
         if matches!(filters.kind, ContentKind::Pr) {
             return Err(AppError::usage(
@@ -184,7 +189,7 @@ impl JiraSource {
         let per_page = Self::bounded_per_page(req.per_page);
         let mut start_at = 0u32;
         let mut next_page_token: Option<String> = None;
-        let mut results = vec![];
+        let mut emitted = 0usize;
 
         loop {
             let url = format!("{}/rest/api/3/search/jql", self.base_url);
@@ -225,7 +230,7 @@ impl JiraSource {
                 } else {
                     vec![]
                 };
-                results.push(Conversation {
+                emit(Conversation {
                     id: issue.key,
                     title: issue.fields.summary,
                     state: issue.fields.status.name,
@@ -236,7 +241,8 @@ impl JiraSource {
                         .map(extract_adf_text)
                         .filter(|s| !s.is_empty()),
                     comments,
-                });
+                })?;
+                emitted += 1;
             }
 
             if let Some(token) = page.next_page_token {
@@ -262,14 +268,18 @@ impl JiraSource {
             break;
         }
 
-        Ok(results)
+        Ok(emitted)
     }
 }
 
 impl Source for JiraSource {
-    fn fetch(&self, req: &FetchRequest) -> Result<Vec<Conversation>> {
+    fn fetch_stream(
+        &self,
+        req: &FetchRequest,
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize> {
         match &req.target {
-            FetchTarget::Search { raw_query } => self.search(req, raw_query),
+            FetchTarget::Search { raw_query } => self.search_stream(req, raw_query, emit),
             FetchTarget::Id { id, kind, .. } => {
                 if matches!(kind, ContentKind::Pr) {
                     return Err(AppError::usage(
@@ -277,7 +287,8 @@ impl Source for JiraSource {
                     )
                     .into());
                 }
-                Ok(vec![self.fetch_issue(id, req)?])
+                emit(self.fetch_issue(id, req)?)?;
+                Ok(1)
             }
         }
     }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -7,13 +7,33 @@ pub mod jira;
 
 /// A pluggable data source that fetches issue/PR conversations.
 pub trait Source {
-    /// Fetch issue or pull request conversations for a request target.
+    /// Fetch issue or pull request conversations for a request target and emit
+    /// each conversation incrementally.
     ///
     /// # Errors
     ///
     /// Returns an error when request validation fails, authentication fails,
     /// or the remote platform returns a non-success/invalid response.
-    fn fetch(&self, req: &FetchRequest) -> Result<Vec<Conversation>>;
+    fn fetch_stream(
+        &self,
+        req: &FetchRequest,
+        emit: &mut dyn FnMut(Conversation) -> Result<()>,
+    ) -> Result<usize>;
+
+    /// Fetch all conversations and collect them into memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when request validation fails, authentication fails,
+    /// remote calls fail, or emitted conversations cannot be collected.
+    fn fetch(&self, req: &FetchRequest) -> Result<Vec<Conversation>> {
+        let mut conversations = Vec::new();
+        self.fetch_stream(req, &mut |conversation| {
+            conversations.push(conversation);
+            Ok(())
+        })?;
+        Ok(conversations)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
refactor sources to emit conversations incrementally via fetch_stream and stream-aware formatters add --output-mode auto|batch|stream and --stream shorthand extend formats with jsonl, ndjson alias, and text
preserve batch mode and regenerate man pages/docs for new flags

Closes #10 